### PR TITLE
Add error log statement when config file can't be opened

### DIFF
--- a/src/inventory.go
+++ b/src/inventory.go
@@ -75,6 +75,7 @@ func setInventoryData(nodeEntity *integration.Entity, overviewData objx.Map) err
 			return nil
 		}
 		if err != nil {
+			logger.Errorf("Could not open the specified configuration file: %v", err)
 			return err
 		}
 		defer checkErr(file.Close)


### PR DESCRIPTION
#### Description of the changes

We weren't seeing any log statements when the config file couldn't be opened because of a permission problem. This should solve that.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [x ] review code for readability
- [x] verify that high risk behavior changes are well tested
- [x] check license for any new external dependency
- [x] ask questions about anything that isn't clear and obvious
- [x] approve the PR when you consider it's good to merge
