### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.0 (2019-11-18)
+### Changed
+- Renamed the integration executable from nr-rabbitmq to nri-rabbitmq in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
 ## 2.1.2 - 2019-11-14
 ### Fixed
 - Exclude windows definition from linux build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.9 as builder
-RUN go get -d github.com/newrelic/nri-rabbitmq/... && \
-    cd /go/src/github.com/newrelic/nri-rabbitmq && \
+COPY . /go/src/github.com/newrelic/nri-rabbitmq/
+RUN cd /go/src/github.com/newrelic/nri-rabbitmq && \
     make && \
-    strip ./bin/nr-rabbitmq
+    strip ./bin/nri-rabbitmq
 
 FROM newrelic/infrastructure:latest
 ENV NRIA_IS_FORWARD_ONLY true
 ENV NRIA_K8S_INTEGRATION true
-COPY --from=builder /go/src/github.com/newrelic/nri-rabbitmq/bin/nr-rabbitmq /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nr-rabbitmq
+COPY --from=builder /go/src/github.com/newrelic/nri-rabbitmq/bin/nri-rabbitmq /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-rabbitmq
 COPY --from=builder /go/src/github.com/newrelic/nri-rabbitmq/rabbitmq-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/definition.yml
 USER 1000

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TARGET_DIR    = $(WORKDIR)/$(TARGET)
 NATIVEOS	 := $(shell go version | awk -F '[ /]' '{print $$4}')
 NATIVEARCH	 := $(shell go version | awk -F '[ /]' '{print $$5}')
 INTEGRATION  := rabbitmq
-BINARY_NAME   = nr-$(INTEGRATION)
+BINARY_NAME   = nri-$(INTEGRATION)
 GOTOOLS       = github.com/kardianos/govendor \
 		gopkg.in/alecthomas/gometalinter.v2 \
 		github.com/axw/gocov/gocov \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The RabbitMQ integration requires that the [RabbitMQ Management Plugin](https://
 
 * download an archive file for the RabbitMQ Integration
 * extract `rabbitmq-definition.yml` and `/bin` directory into `/var/db/newrelic-infra/newrelic-integrations`
-* add execute permissions for the binary file `nr-rabbitmq` (if necessary)
+* add execute permissions for the binary file `nri-rabbitmq` (if necessary)
 * extract `rabbitmq-config.yml.sample` into `/etc/newrelic-infra/integrations.d`
 
 ## Usage
@@ -33,11 +33,11 @@ For managing external dependencies [govendor tool](https://github.com/kardianos/
 ```bash
 $ make
 ```
-* The above command will run tests for the integration and build an executable file called `nr-rabbitmq` in the `/bin` directory. This executable can be run by itself:
+* The above command will run tests for the integration and build an executable file called `nri-rabbitmq` in the `/bin` directory. This executable can be run by itself:
 ```bash
-$ ./bin/nr-rabbitmq
+$ ./bin/nri-rabbitmq
 ```
 * For additional usage information use the `-help` flag:
 ```bash
-$ ./bin/nr-rabbitmq -help
+$ ./bin/nri-rabbitmq -help
 ```

--- a/rabbitmq-definition.yml
+++ b/rabbitmq-definition.yml
@@ -6,19 +6,19 @@ os: linux
 commands:
   all:
     command:
-      - ./bin/nr-rabbitmq
+      - ./bin/nri-rabbitmq
     prefix: config/rabbitmq
     interval: 15
 
   inventory:
     command:
-      - ./bin/nr-rabbitmq
+      - ./bin/nri-rabbitmq
       - -inventory
     prefix: config/rabbitmq
     interval: 15
   
   events:
     command:
-      - ./bin/nr-rabbitmq
+      - ./bin/nri-rabbitmq
       - -events
     interval: 15

--- a/rabbitmq-win-definition.yml
+++ b/rabbitmq-win-definition.yml
@@ -6,19 +6,19 @@ os: windows
 commands:
   all:
     command:
-      - .\bin\nr-rabbitmq.exe
+      - .\bin\nri-rabbitmq.exe
     prefix: config/rabbitmq
     interval: 15
 
   inventory:
     command:
-      - .\bin\nr-rabbitmq.exe
+      - .\bin\nri-rabbitmq.exe
       - -inventory
     prefix: config/rabbitmq
     interval: 15
   
   events:
     command:
-      - .\bin\nr-rabbitmq.exe
+      - .\bin\nri-rabbitmq.exe
       - -events
     interval: 15

--- a/src/rabbitmq.go
+++ b/src/rabbitmq.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.rabbitmq"
-	integrationVersion = "2.1.2"
+	integrationVersion = "2.2.0"
 )
 
 func main() {

--- a/src/rabbitmq_test.go
+++ b/src/rabbitmq_test.go
@@ -32,7 +32,7 @@ func Test_main(t *testing.T) {
 	})
 	origArgs := os.Args
 	os.Args = []string{
-		"nr-rabbitmq",
+		"nri-rabbitmq",
 		"-node_name_override", "node1",
 		"-config_path", "",
 		"-hostname", args.GlobalArgs.Hostname,

--- a/win_build.ps1
+++ b/win_build.ps1
@@ -15,7 +15,7 @@ param (
 
 $integration = $(Split-Path -Leaf $PSScriptRoot)
 $integrationName = $integration.Replace("nri-", "")
-$executable = "nr-$integrationName.exe"
+$executable = "nri-$integrationName.exe"
 
 # verifying version number format
 $v = $version.Split(".")

--- a/windows_set_version.ps1
+++ b/windows_set_version.ps1
@@ -7,7 +7,7 @@ param (
 
 $integration = $(Split-Path -Leaf $PSScriptRoot)
 $integrationName = $integration.Replace("nri-", "")
-$executable = "nr-$integrationName.exe"
+$executable = "nri-$integrationName.exe"
 
 if (-not (Test-Path env:GOPATH)) {
 	Write-Error "GOPATH not defined."


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-rabbitmq to nri-rabbitmq in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.