### PR TITLE
Modified name of yaml from haproxy to rabbitmq

### DIFF
--- a/rabbitmq-config.yml.k8s_sample
+++ b/rabbitmq-config.yml.k8s_sample
@@ -1,4 +1,4 @@
-  haproxy-config.yml: |
+ rabbitmq-config.yml: |
     ---
     # Run auto discovery to find pods with label "app=rabbitmq"
     # https://docs.newrelic.com/docs/integrations/host-integrations/installation/container-auto-discovery


### PR DESCRIPTION
#### Description of the changes

Name of yaml was set to haproxy-config.yml instead of rabbitmq-config.yml