### PR TITLE
Increase queue limit to 2000 from 500

### DIFF
--- a/src/rabbitmq.go
+++ b/src/rabbitmq.go
@@ -131,7 +131,7 @@ func getEventData(rabbitData *allData) {
 // maxQueues is the maximum amount of Queues that can be collect.
 // If there are more than this number of Queues then collection of
 // Queues will fail.
-const maxQueues = 500
+const maxQueues = 2000
 
 func getMetricEntities(apiData *allData) []data.EntityData {
 	i := 0


### PR DESCRIPTION
#### Description of the changes

The maximum number of queues limit is changed from 500 to 2000 to better serve larger enterprise deployments. There is no indication of the reasoning for this arbitrary value.

Issue: #49 

#### PR Review Checklist
### Author

- [√] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ √ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
