### PR TITLE
Fix clusterName and entity collisions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 ARG GOLANG_VERSION=1.16
 
 FROM golang:${GOLANG_VERSION} as builder
+
 WORKDIR /code
-COPY go.mod .
-RUN go mod download
-
 COPY . ./
-RUN go build -o ./bin/nri-rabbitmq src/; strip ./bin/nri-rabbitmq
+RUN make compile; strip ./bin/nri-rabbitmq
 
 
-FROM newrelic/infrastructure:latest
-ENV NRIA_IS_FORWARD_ONLY true
-ENV NRIA_K8S_INTEGRATION true
-COPY --from=builder /code/bin/nri-rabbitmq /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-rabbitmq
-USER 1000
+FROM newrelic/infrastructure-bundle:latest
+COPY --from=builder /code/bin/nri-rabbitmq /var/db/newrelic-infra/newrelic-integrations/bin/nri-rabbitmq

--- a/src/data/integration.go
+++ b/src/data/integration.go
@@ -3,9 +3,10 @@ package data
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	args2 "github.com/newrelic/nri-rabbitmq/src/args"
 	consts2 "github.com/newrelic/nri-rabbitmq/src/data/consts"
-	"strings"
 
 	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 
@@ -33,11 +34,12 @@ func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, enti
 
 	clusterNameAttribute := integration.IDAttribute{Key: "clusterName", Value: clusterName}
 	endpoint := fmt.Sprintf("%s:%d", args2.GlobalArgs.Hostname, args2.GlobalArgs.Port)
+
+	entity, err = rabbitmqIntegration.EntityReportedVia(endpoint, fmt.Sprintf("%s:%s", endpoint, name), fmt.Sprintf("ra-%s", entityType), clusterNameAttribute)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	entity, err = rabbitmqIntegration.EntityReportedVia(endpoint, fmt.Sprintf("%s:%s", endpoint, name), fmt.Sprintf("ra-%s", entityType), clusterNameAttribute)
 	return
 }
 

--- a/src/data/integration.go
+++ b/src/data/integration.go
@@ -28,7 +28,7 @@ func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, enti
 	metricNamespace = []attribute.Attribute{
 		{Key: "displayName", Value: name},
 		{Key: "entityName", Value: fmt.Sprintf("%s:%s", entityType, name)},
-		{Key: "clusterName", Value: clusterName},
+		{Key: "rabbitmqClusterName", Value: clusterName},
 	}
 
 	clusterNameAttribute := integration.IDAttribute{Key: "clusterName", Value: clusterName}

--- a/src/data/integration.go
+++ b/src/data/integration.go
@@ -37,7 +37,7 @@ func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, enti
 		return nil, nil, err
 	}
 
-	entity, err = rabbitmqIntegration.EntityReportedVia(endpoint, name, fmt.Sprintf("ra-%s", entityType), clusterNameAttribute)
+	entity, err = rabbitmqIntegration.EntityReportedVia(endpoint, fmt.Sprintf("%s:%s", endpoint, name), fmt.Sprintf("ra-%s", entityType), clusterNameAttribute)
 	return
 }
 

--- a/src/events_test.go
+++ b/src/events_test.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/newrelic/nri-rabbitmq/src/args"
 	"github.com/newrelic/nri-rabbitmq/src/data"
 	"github.com/newrelic/nri-rabbitmq/src/testutils"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	// TODO remove global args.
+	// This test are heavily based on global args to filter entities on creation.
+	args.GlobalArgs.Vhosts = []string{"vhost1"}
+}
 
 func Test_alivenessTest_Pass(t *testing.T) {
 	i := testutils.GetTestingIntegration(t)
@@ -29,7 +36,7 @@ func Test_alivenessTest_FailCreateEntity(t *testing.T) {
 
 	vhostTests := []*data.VhostTest{
 		{
-			Vhost: &data.VhostData{},
+			Vhost: &data.VhostData{Name: "bar"},
 			Test:  &data.TestData{},
 		},
 	}
@@ -87,19 +94,6 @@ func Test_healthcheckTest_Pass(t *testing.T) {
 			Test: &data.TestData{
 				Status: "ok",
 			},
-		},
-	}
-	healthcheckTest(i, nodeTests, "testClusterName")
-	assert.Empty(t, i.Entities)
-}
-
-func Test_healthcheckTest_FailCreateEntity(t *testing.T) {
-	i := testutils.GetTestingIntegration(t)
-
-	nodeTests := []*data.NodeTest{
-		{
-			Node: &data.NodeData{},
-			Test: &data.TestData{},
 		},
 	}
 	healthcheckTest(i, nodeTests, "testClusterName")

--- a/src/metrics/cluster_test.go
+++ b/src/metrics/cluster_test.go
@@ -1,13 +1,25 @@
 package metrics
 
 import (
-	data2 "github.com/newrelic/nri-rabbitmq/src/data"
-	testutils2 "github.com/newrelic/nri-rabbitmq/src/testutils"
+	"fmt"
 	"path/filepath"
 	"testing"
 
+	"github.com/newrelic/nri-rabbitmq/src/args"
+	data2 "github.com/newrelic/nri-rabbitmq/src/data"
+	testutils2 "github.com/newrelic/nri-rabbitmq/src/testutils"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	// TODO remove global args.
+	// This test are heavily based on global args to create entities.
+	args.GlobalArgs = args.RabbitMQArguments{
+		Hostname: "foo",
+		Port:     8000,
+	}
+}
 
 func TestPopulateClusterInventory(t *testing.T) {
 	i := testutils2.GetTestingIntegration(t)
@@ -22,8 +34,10 @@ func TestPopulateClusterInventory(t *testing.T) {
 
 	PopulateClusterData(i, overviewData)
 	assert.Equal(t, 1, len(i.Entities))
-	assert.Equal(t, "my-cluster", i.Entities[0].Metadata.Name)
-	assert.Equal(t, "ra-cluster", i.Entities[0].Metadata.Namespace)
+
+	entityKeyPrefix := fmt.Sprintf("%s:%d:", args.GlobalArgs.Hostname, args.GlobalArgs.Port)
+	assert.Equal(t, entityKeyPrefix+"my-cluster", i.Entities[0].Metadata.Name)
+	assert.Equal(t, entityKeyPrefix+"ra-cluster", i.Entities[0].Metadata.Namespace)
 	assert.Equal(t, 2, len(i.Entities[0].Inventory.Items()))
 
 	item, ok := i.Entities[0].Inventory.Item("version/rabbitmq")


### PR DESCRIPTION
# Breaking
Replace the attribute `clusterName` to `rabbitmqClusterName` to avoid collisions with the `clusterName` attribute reported when running in k8s. Naming was taken from [HAproxy integration fix](https://github.com/newrelic/nri-haproxy/blob/master/src/collection.go#L160) . User that have been use `clusterName` attribute will need to replace it with `rabbitmqClusterName`.

Adds the `host:port` to all entity keys in order to use the entityRewrite when running in k8s. This fixes #73 . When the new version of the integration is deployed entities will be recreated with this new name. Old entities will live for an [extra day](https://github.com/newrelic/entity-definitions/blob/main/definitions/infra-rabbitmqqueue/definition.yml#L6).
example: 

`entityKey`(before):`ra-queue:/aliveness-test:clustername=rabbit@rabbitmq-0.rabbitmq-headless.rabbitmq.svc.cluster.local`

`entityKey`(fixed):`ra-queue:k8s:k8s-cluster-name:rabbitmq:pod:rabbitmq-0:rabbitmq:15672:/aliveness-test:clustername=rabbit@rabbitmq-0.rabbitmq-headless.rabbitmq.svc.cluster.local`

