### PR TITLE
New Logging Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.4.2  (2022-03-17)
+### Added
+- `rabbitmq-log.yml.example` is now in Linux packages to help setting up log parsing.
+
 ## 2.4.1 (2021-10-20)
 ### Added
 Added support for more distributions:

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -48,6 +48,8 @@ nfpms:
     contents:
       - src: "rabbitmq-config.yml.sample"
         dst: "/etc/newrelic-infra/integrations.d/rabbitmq-config.yml.sample"
+      - src: "rabbitmq-log.yml.example"
+        dst: "/etc/newrelic-infra/logging.d/rabbitmq-log.yml.example"
       - src: "CHANGELOG.md"
         dst: "/usr/share/doc/nri-rabbitmq/CHANGELOG.md"
       - src: "README.md"

--- a/rabbitmq-log.yml.example
+++ b/rabbitmq-log.yml.example
@@ -1,0 +1,12 @@
+###############################################################################
+# This sample file will forward rabbitmq error logs to NR once                #
+#   it is renamed to rabbitmq-log.yml                                         #
+# On Linux systems no restart is needed after it is renamed                   #
+# Source: rabbitmq error log file                                             #
+# Available customization parameters: attributes, max_line_kb, pattern        #
+###############################################################################
+logs:
+  - name: "rabbitmqlog"
+    file: /var/log/rabbitmq/*.log
+    attributes:
+      logtype: rabbitmq


### PR DESCRIPTION
This is the initial commit of the new Rabbitmq logging template file. By renaming this file (dropping the .example) customers can now automatically send parsed Rabbitmq logs to NR.