### PR TITLE
Pipeline refactor

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
+          go-version-file: src\github.com\${{ env.ORIGINAL_REPO_NAME }}\go.mod
       - name: Running unit tests
         shell: pwsh
         run: |
@@ -118,11 +118,11 @@ jobs:
       - name: Download zip from GH Release assets and extract .exe
         shell: pwsh
         run: |
-          build\windows\download_zip_extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\download_zip.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
       - name: Create MSI
         shell: pwsh
-        run: |
-          build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"
+        run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"
       - name: Test win packages installation
         uses: newrelic/integrations-pkg-test-action/windows@v1
         with:
@@ -133,8 +133,7 @@ jobs:
       - name: Upload MSI to GH
         if: startsWith(matrix.test-upgrade, 'false')
         shell: bash
-        run: |
-          build/windows/upload_msi.sh ${INTEGRATION} ${{ matrix.goarch }} ${TAG}
+        run: build/windows/upload_msi.sh ${INTEGRATION} ${{ matrix.goarch }} ${TAG}
       - name: Notify failure via Slack
         if: ${{ failure() }}
         uses: archive/github-actions-slack@master

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -6,12 +6,13 @@ on:
       - main
       - master
   pull_request:
+  workflow_dispatch:
 
 env:
-  TAG: "v0.0.0" # needed for goreleaser windows builds
+  INTEGRATION: "rabbitmq"
+  ORIGINAL_REPO_NAME: 'newrelic/nri-rabbitmq'
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  ORIGINAL_REPO_NAME: "newrelic/nri-rabbitmq"
-  DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+  TAG: "v1.2.3"  # needed for fake-prereleases
 
 jobs:
   static-analysis:
@@ -83,10 +84,68 @@ jobs:
           GOPATH: ${{ github.workspace }}
         run: make integration-test
 
-  test-build:
-    name: Test binary compilation for all platforms:arch
+  test-build-nix:
+    name: Test binary compilation and packaging for linux
     runs-on: ubuntu-latest
+    env:
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
     steps:
       - uses: actions/checkout@v3
+      - run: |
+          git tag "$TAG"
+          if [ -z "$GPG_PASSPHRASE" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          fi
       - name: Build all platforms:arch
-        run: make ci/build
+        run: make ci/fake-prerelease
+      - name: Upload artifacts for next job
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-packages
+          path: dist/nri-*.zip
+
+  test-build-windows:
+    name: Create MSI
+    runs-on: windows-latest
+    needs: [test-build-nix]
+    env:
+      GOPATH: ${{ github.workspace }}
+      PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
+      PFX_CERTIFICATE_DESCRIPTION: 'New Relic'
+      PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}
+    defaults:
+      run:
+        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+    strategy:
+      matrix:
+        goarch: [amd64,386]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+      - shell: bash
+        run: git tag "$TAG"
+
+      - name: Download artifact from previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-packages
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/dist/
+
+      - name: Get PFX certificate from GH secrets
+        shell: bash
+        run: |
+          if [ -z "$PFX_CERTIFICATE_BASE64" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          else
+            printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+          fi
+      - name: Extract .exe
+        shell: pwsh
+        run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
+      - name: Create MSI
+        shell: pwsh
+        run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -27,7 +27,8 @@ builds:
       - 386
       - amd64
     hooks:
-      pre: build/windows/set_exe_properties.sh {{ .Env.TAG }} "rabbitmq"
+      pre: 
+        - build/windows/set_exe_properties.sh {{ .Env.TAG }} "rabbitmq"
 
 nfpms:
   - id: linux
@@ -78,6 +79,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
       - rabbitmq-config.yml.sample
+      - rabbitmq-log.yml.example
       - src: 'legacy/rabbitmq-definition.yml'
         dst: .
         strip_parent: true

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -51,6 +51,7 @@ ifdef TAG
 			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-e INTEGRATION \
 			-e PRERELEASE=true \
+			-e NO_SIGN \
 			-e GITHUB_TOKEN \
 			-e REPO_FULL_NAME \
 			-e TAG \
@@ -60,5 +61,27 @@ ifdef TAG
 			$(BUILDER_TAG) make release
 else
 	@echo "===> $(INTEGRATION) ===  [ci/prerelease] TAG env variable expected to be set"
+	exit 1
+endif
+
+.PHONY : ci/fake-prerelease
+ci/fake-prerelease: ci/deps
+ifdef TAG
+	@docker run --rm -t \
+			--name "nri-$(INTEGRATION)-prerelease" \
+			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-e INTEGRATION \
+			-e PRERELEASE=true \
+			-e NO_PUBLISH=true \
+			-e GITHUB_TOKEN \
+			-e REPO_FULL_NAME \
+			-e TAG \
+			-e GPG_MAIL \
+			-e GPG_PASSPHRASE \
+			-e GPG_PRIVATE_KEY_BASE64 \
+			$(BUILDER_TAG) make release
+else
+	@echo "===> $(INTEGRATION) ===  [ci/fake-prerelease] TAG env variable expected to be set"
 	exit 1
 endif

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-386</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-amd64</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/release.mk
+++ b/build/release.mk
@@ -41,15 +41,22 @@ release/fix-archive:
 	@bash $(CURDIR)/build/windows/fix_archives.sh $(CURDIR)
 
 .PHONY : release/sign/nix
+ifneq ($(NO_SIGN), true)
 release/sign/nix:
 	@echo "===> $(INTEGRATION) === [release/sign] signing packages"
 	@bash $(CURDIR)/build/nix/sign.sh
-
+else
+	@echo "===> $(INTEGRATION) === [release/sign] signing packages is disabled by environment variable"
+endif
 
 .PHONY : release/publish
 release/publish:
+ifneq ($(NO_PUBLISH), true)
 	@echo "===> $(INTEGRATION) === [release/publish] publishing artifacts"
 	@bash $(CURDIR)/build/upload_artifacts_gh.sh
+else
+	@echo "===> $(INTEGRATION) === [release/publish] publish is disabled by environment variable"
+endif
 
 .PHONY : release
 release: release/build release/fix-archive release/sign/nix release/publish release/clean

--- a/build/windows/download_zip.ps1
+++ b/build/windows/download_zip.ps1
@@ -5,15 +5,12 @@ param (
     [string]$REPO_FULL_NAME="none"
 )
 write-host "===> Creating dist folder"
-New-Item -ItemType directory -Path .\dist
+New-Item -ItemType directory -Path .\dist -Force
 
 $VERSION=${TAG}.substring(1)
-$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
 $zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
 
 $zip_url="https://github.com/${REPO_FULL_NAME}/releases/download/${TAG}/${zip_name}"
 write-host "===> Downloading & extracting .exe from ${zip_url}"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest "${zip_url}" -OutFile ".\dist\${zip_name}"
-write-host "===> Expanding"
-expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/extract_exe.ps1
+++ b/build/windows/extract_exe.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$INTEGRATION="none",
+    [string]$ARCH="amd64",
+    [string]$TAG="v0.0.0"
+)
+write-host "===> Creating dist folder"
+New-Item -ItemType directory -Path .\dist -Force
+
+$VERSION=${TAG}.substring(1)
+$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
+$zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
+
+write-host "===> Expanding"
+expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/package_msi.ps1
+++ b/build/windows/package_msi.ps1
@@ -30,11 +30,16 @@ if ($wrong.Length  -ne 0) {
     exit -1
 }
 
-echo "===> Import .pfx certificate from GH Secrets"
-Import-PfxCertificate -FilePath wincert.pfx -Password (ConvertTo-SecureString -String $pfx_passphrase -AsPlainText -Force) -CertStoreLocation Cert:\CurrentUser\My
+$noSign = $env:NO_SIGN ?? "false"
+if ($noSign -ieq "true") {
+    echo "===> Import .pfx certificate is disabled by environment variable"
+} else {
+    echo "===> Import .pfx certificate from GH Secrets"
+    Import-PfxCertificate -FilePath wincert.pfx -Password (ConvertTo-SecureString -String $pfx_passphrase -AsPlainText -Force) -CertStoreLocation Cert:\CurrentUser\My
 
-echo "===> Show certificate installed"
-Get-ChildItem -Path cert:\CurrentUser\My\
+    echo "===> Show certificate installed"
+    Get-ChildItem -Path cert:\CurrentUser\My\
+}
 
 echo "===> Checking MSBuild.exe..."
 $msBuild = (Get-ItemProperty hklm:\software\Microsoft\MSBuild\ToolsVersions\4.0).MSBuildToolsPath
@@ -47,7 +52,7 @@ echo $msBuild
 echo "===> Building Installer"
 Push-Location -Path "build\package\windows\nri-$arch-installer"
 
-. $msBuild/MSBuild.exe nri-installer.wixproj /p:IntegrationVersion=${version} /p:IntegrationName=$integration /p:Year=$buildYear /p:pfx_certificate_description=$pfx_certificate_description
+. $msBuild/MSBuild.exe nri-installer.wixproj /p:IntegrationVersion=${version} /p:IntegrationName=$integration /p:Year=$buildYear /p:NoSign=$noSign /p:pfx_certificate_description=$pfx_certificate_description
 
 if (-not $?)
 {


### PR DESCRIPTION
We are not testing packaging at PR time. This PR adds `fake-prerelease` target to the makefile that does exactly the same as `prerelease` without uploading the artifacts to GitHub.

This should be enough to test that the packages are correctly created in both operative systems.
