### PR TITLE
Add DisableEntities flag

### DIFF
--- a/src/args/args.go
+++ b/src/args/args.go
@@ -23,4 +23,5 @@ type ArgumentList struct {
 	VhostsRegexes        string `default:"" help:"JSON array of vhost name regexes from which to collect metrics."`
 	ShowVersion          bool   `default:"false" help:"Print build information and exit"`
 	Timeout              int    `default:"30" help:"Timeout in seconds to timeout the connection to RabbitMQ endpoint."`
+	DisableEntities      bool   `default:"false" help:"configure whether inventory entries are created for entities."`
 }

--- a/src/args/rabbitmq_args.go
+++ b/src/args/rabbitmq_args.go
@@ -27,6 +27,7 @@ type RabbitMQArguments struct {
 	ConfigPath           string
 	UseSSL               bool
 	Timeout              int
+	DisableEntities      bool
 	Queues               []string
 	QueuesRegexes        []*regexp.Regexp
 	Exchanges            []string
@@ -101,6 +102,7 @@ func SetGlobalArgs(args ArgumentList) error {
 		Username:             args.Username,
 		UseSSL:               args.UseSSL,
 		Timeout:              args.Timeout,
+		DisableEntities:      args.DisableEntities,
 	}
 	var err error
 	if err = parseStrings(args.Exchanges, &rabbitArgs.Exchanges); err != nil {

--- a/src/metrics/metric_test.go
+++ b/src/metrics/metric_test.go
@@ -32,10 +32,27 @@ func TestCollectEntityMetrics(t *testing.T) {
 	i := testutils.GetTestingIntegration(t)
 	CollectEntityMetrics(i, []*data.BindingData{},
 		"testClusterName",
-		&data.NodeData{Name: "node1"},
+		&data.ExchangeData{Name: "exchange1"},
 		&data.QueueData{Name: "queue1"},
 	)
 	assert.Equal(t, 2, len(i.Entities))
+	for _, e := range i.Entities {
+		assert.Greater(t, len(e.Inventory.Items()), 1)
+	}
+}
+
+func TestCollectEntityMetrics_DisabledInventory(t *testing.T) {
+	i := testutils.GetTestingIntegration(t)
+	args.GlobalArgs.DisableEntities = true
+	CollectEntityMetrics(i, []*data.BindingData{},
+		"testClusterName",
+		&data.QueueData{Name: "queue1"},
+		&data.ExchangeData{Name: "exchange1"},
+	)
+	assert.Equal(t, 2, len(i.Entities))
+	for _, e := range i.Entities {
+		assert.Len(t, e.Inventory.Items(), 0)
+	}
 }
 
 func Test_setMetric(t *testing.T) {


### PR DESCRIPTION
Currently, the integration adds inventory entries when collecting metrics only for the entity generation proposes. 
This could cause issues when the amount of entities is large, and as a workaround this flag would enable to stop the entities creation and only report Samples. 

A following PR for a flag disabling the maxQueue number could be done to allow large amount of queues collection with this workaround.