### PR TITLE
Expose max queue limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.10.2  (2023-04-20)
+### Added
+- Exposed the 'QueuesMaxLimit' flag to configure the max amount of queues collected.
+- Added a 'DisableEntities' flag to avoid generating inventory entries on large environments
+
 ## 2.10.1  (2023-04-05)
 ### Changed
 - Fix log example file path in unix tarballs

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -23,5 +23,9 @@ type ArgumentList struct {
 	VhostsRegexes        string `default:"" help:"JSON array of vhost name regexes from which to collect metrics."`
 	ShowVersion          bool   `default:"false" help:"Print build information and exit"`
 	Timeout              int    `default:"30" help:"Timeout in seconds to timeout the connection to RabbitMQ endpoint."`
-	DisableEntities      bool   `default:"false" help:"configure whether inventory entries are created for entities."`
+	DisableEntities      bool   `default:"false" help:"configure whether inventory entries are created for entities during metrics collection."`
+
+	// The reason is that each queue generates an inventory entry (for entity creation proposes)
+	// and the Agent is not capable of processing a higher amount of inventory entries.
+	QueuesMaxLimit int `default:"2000" help:"Defines the max amount of Queues that can be processed, if this number is reached all queues will be dropped. If defined as '0' no limits are applied"`
 }

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -23,9 +23,9 @@ type ArgumentList struct {
 	VhostsRegexes        string `default:"" help:"JSON array of vhost name regexes from which to collect metrics."`
 	ShowVersion          bool   `default:"false" help:"Print build information and exit"`
 	Timeout              int    `default:"30" help:"Timeout in seconds to timeout the connection to RabbitMQ endpoint."`
-	DisableEntities      bool   `default:"false" help:"configure whether inventory entries are created for entities during metrics collection."`
 
 	// The reason is that each queue generates an inventory entry (for entity creation proposes)
 	// and the Agent is not capable of processing a higher amount of inventory entries.
-	QueuesMaxLimit int `default:"2000" help:"Defines the max amount of Queues that can be processed, if this number is reached all queues will be dropped. If defined as '0' no limits are applied"`
+	QueuesMaxLimit  int  `default:"2000" help:"Defines the max amount of Queues that can be processed, if this number is reached all queues will be dropped. If defined as '0' no limits are applied"`
+	DisableEntities bool `default:"false" help:"configure whether inventory entries are created for entities during metrics collection."`
 }

--- a/src/args/rabbitmq_args.go
+++ b/src/args/rabbitmq_args.go
@@ -28,6 +28,7 @@ type RabbitMQArguments struct {
 	UseSSL               bool
 	Timeout              int
 	DisableEntities      bool
+	QueuesMaxLimit       int
 	Queues               []string
 	QueuesRegexes        []*regexp.Regexp
 	Exchanges            []string
@@ -103,6 +104,7 @@ func SetGlobalArgs(args ArgumentList) error {
 		UseSSL:               args.UseSSL,
 		Timeout:              args.Timeout,
 		DisableEntities:      args.DisableEntities,
+		QueuesMaxLimit:       args.QueuesMaxLimit,
 	}
 	var err error
 	if err = parseStrings(args.Exchanges, &rabbitArgs.Exchanges); err != nil {

--- a/src/rabbitmq.go
+++ b/src/rabbitmq.go
@@ -153,6 +153,11 @@ func getMetricEntities(apiData *allData) []data.EntityData {
 		return dataItems
 	}
 
+	// keeping this message here so all queue limit stuff are together.
+	if args.GlobalArgs.QueuesMaxLimit == 0 && !args.GlobalArgs.DisableEntities {
+		log.Warn("QueuesMaxLimit has been disable (=0) but the entities generation has not been disabled (DisableEntities) this could cause hugh time and memory increase when metrics are processed by the Agent")
+	}
+
 	for _, v := range apiData.queues {
 		dataItems = append(dataItems, v)
 	}

--- a/src/rabbitmq.go
+++ b/src/rabbitmq.go
@@ -155,7 +155,7 @@ func getMetricEntities(apiData *allData) []data.EntityData {
 
 	// keeping this message here so all queue limit stuff are together.
 	if args.GlobalArgs.QueuesMaxLimit == 0 && !args.GlobalArgs.DisableEntities {
-		log.Warn("QueuesMaxLimit has been disable (=0) but the entities generation has not been disabled (DisableEntities) this could cause hugh time and memory increase when metrics are processed by the Agent")
+		log.Warn("QueuesMaxLimit has been disabled (=0) but the entities generation has not been disabled (DisableEntities) this could cause huge time and memory increase when metrics are processed by the Agent")
 	}
 
 	for _, v := range apiData.queues {

--- a/src/rabbitmq.go
+++ b/src/rabbitmq.go
@@ -132,11 +132,6 @@ func getEventData(rabbitData *allData) {
 	}
 }
 
-// maxQueues is the maximum amount of Queues that can be collect.
-// The reason is that each queue generates an inventory entry (for entity creation proposes)
-// and the Agent is not capable of processing a higher amount of inventory entries.
-const maxQueues = 2000
-
 func getMetricEntities(apiData *allData) []data.EntityData {
 	i := 0
 	// Make the length the size of nodes and exchanges but capacity the length + size of queues. This is to accommodate the chance that there are more
@@ -152,8 +147,9 @@ func getMetricEntities(apiData *allData) []data.EntityData {
 		i++
 	}
 
-	if queueLength := getFilteredQueueCount(apiData.queues); queueLength > maxQueues {
-		log.Error("There are %d queues in collection, the maximum amount of queues to collect is %d. Use the queue whitelist or regex configuration parameter to limit collection size.", queueLength, maxQueues)
+	queueLength := getFilteredQueueCount(apiData.queues)
+	if queueLength > args.GlobalArgs.QueuesMaxLimit && args.GlobalArgs.QueuesMaxLimit != 0 {
+		log.Error("There are %d queues in collection, the maximum amount of queues to collect is %d. Use the queue whitelist or regex configuration parameter to limit collection size.", queueLength, args.GlobalArgs.QueuesMaxLimit)
 		return dataItems
 	}
 


### PR DESCRIPTION
Exposing this limit will allow ingesting large amounts of queues. Incrementing this parameter alongside `DisableEntities` arg will allow to collect and send only Samples.