### PR TITLE
NR-121914: use release toolkit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "github>newrelic/coreint-automation:renovate-base.json5"
+  ]
+}

--- a/.github/workflows/on_prerelease.yml
+++ b/.github/workflows/on_prerelease.yml
@@ -1,4 +1,4 @@
-name: Prerelease pipeline
+name: Create prerelease artifacts
 
 on:
   release:
@@ -78,13 +78,6 @@ jobs:
           GPG_MAIL: 'infrastructure-eng@newrelic.com'
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-      - name: Notify failure via Slack
-        if: ${{ failure() }}
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
       - name: Test package installability
         uses: newrelic/integrations-pkg-test-action/linux@v1
         with:
@@ -134,14 +127,6 @@ jobs:
         if: startsWith(matrix.test-upgrade, 'false')
         shell: bash
         run: build/windows/upload_msi.sh ${INTEGRATION} ${{ matrix.goarch }} ${TAG}
-      - name: Notify failure via Slack
-        if: ${{ failure() }}
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
-
 
   publish-to-s3:
     name: Send release assets to S3
@@ -181,3 +166,15 @@ jobs:
           packageLocation: repo
           stagingRepo: true
           upgrade: false
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [test-nix, test-windows, test-integration-nix, prerelease, package-win, publish-to-s3]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [prerelease pipeline failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -1,4 +1,4 @@
-name: Release pipeline
+name: Create release artifacts
 
 on:
   release:
@@ -53,3 +53,15 @@ jobs:
           integration: 'nri-${{ env.INTEGRATION }}' # Required, with nri- prefix
           packageLocation: repo
           upgrade: false
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [publish-to-s3]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [release pipeline failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - renovate/**
   pull_request:
   workflow_dispatch:
 
@@ -32,6 +33,8 @@ jobs:
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           only-new-issues: true
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1
 
   test-nix:
     name: Run unit tests on *Nix

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - renovate/**
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  trivy:
+    name: Trivy security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.7.1
+        if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          exit-code: 1
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: 'build'
+
+      - name: Run Trivy vulnerability scanner sarif output
+        uses: aquasecurity/trivy-action@0.7.1
+        if: ${{ github.event.schedule }} # Generate sarif when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          skip-dirs: 'build'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: ${{ github.event.schedule }} # Upload sarif when running periodically
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trigger_prerelease.yml
+++ b/.github/workflows/trigger_prerelease.yml
@@ -1,0 +1,21 @@
+
+name: Trigger prerelease creation
+
+# This workflow triggers a prerelease creation with changelog and the release notes created by the release toolkit.
+# This workflow should be triggered merely from the default branch.
+# If you wish to be 100% free creating a prerelease, just create it manually.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 5 * * 3"
+
+jobs:
+  prerelease:
+    uses: newrelic/coreint-automation/.github/workflows/trigger_prerelease.yaml@v1
+    secrets:
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      slack_channel:  ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
+    with:
+      rt-included-files: go.mod,go.sum,build/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ internal/versioninfo.json
 internal/resource.syso
 
 vendor
+
+# Release toolkit
+CHANGELOG.partial.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
+## Unreleased
 
 ## 2.12.0  (2023-06-08)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
+### enhancement
+ - bumped golang version pinning 1.20.6
 
 ## 2.12.0  (2023-06-08)
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,15 @@ install: compile
 	@sudo install -D --mode=755 --owner=root --strip $(ROOT)bin/$(BINARY_NAME) $(INTEGRATIONS_DIR)/bin/$(BINARY_NAME)
 	@sudo install -D --mode=644 --owner=root $(ROOT)$(INTEGRATION)-config.yml.sample $(CONFIG_DIR)/$(INTEGRATION)-config.yml.sample
 
+# rt-update-changelog runs the release-toolkit run.sh script by piping it into bash to update the CHANGELOG.md.
+# It also passes down to the script all the flags added to the make target. To check all the accepted flags,
+# see: https://github.com/newrelic/release-toolkit/blob/main/contrib/ohi-release-notes/run.sh
+#  e.g. `make rt-update-changelog -- -v`
+rt-update-changelog:
+	curl "https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/run.sh" | bash -s -- $(filter-out $@,$(MAKECMDGOALS))
+
 # Include thematic Makefiles
 include $(CURDIR)/build/ci.mk
 include $(CURDIR)/build/release.mk
 
-.PHONY: all build clean compile test integration-test install
+.PHONY: all build clean compile test integration-test install rt-update-changelog

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.20.6-bookworm
 
 ARG GH_VERSION='2.23.0'
 


### PR DESCRIPTION
- [x] The branch of the PR is prefixed with renovate/*
- [x] Tests pass in renovate branches
- [x] security workflow is included and will pass in renovate branches
- [x] the changelog is validated in push_pr workflow
- [x] The repository has the secrets available
- [x] Release schedule is documented and not colliding
- [x] rt-update-changelog is in Makefile
- [x] Tags with leading v are safe
- [x] Common renovate config is pointed
- [x] Potential troublesome dependencies are checked
- [x] pre-release and release workflows are updated to notify failures
- [x] CHANGELOG.partial.md is in .gitignore
- [x] release-toolkit action excluded/included fields are set
- [x] Docker image pings go patch version
- [ ] The dependency dashboard is sanitized --> It will be enabled when the PR is merged, and then we need to remove Worktato comment and set `dependencies` label.