### PR TITLE
fix(logs): lowering error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
+### bugfix
+- we were logging an error message even if there was no actual error causing a weird `\u003cnil\u003e` to show up in the logs.
+
 ## v2.13.6 - 2024-05-15
 
 ### ⛓️ Dependencies

--- a/src/data/integration.go
+++ b/src/data/integration.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateEntity will create an entity and metricNamespace attributes with appropriate name/namespace values if the entity isn't filtered
-func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, entityType, vhost, clusterName string) (entity *integration.Entity, metricNamespace []attribute.Attribute, err error) {
+func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, entityType, vhost, clusterName string) (*integration.Entity, []attribute.Attribute, error) {
 	name := cleanEntityName(entityName, entityType)
 
 	if !args.GlobalArgs.IncludeEntity(name, entityType, vhost) {
@@ -25,7 +25,7 @@ func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, enti
 	if entityType == consts.QueueType || entityType == consts.ExchangeType {
 		name = joinVhostName(vhost, name)
 	}
-	metricNamespace = []attribute.Attribute{
+	metricNamespace := []attribute.Attribute{
 		{Key: "displayName", Value: name},
 		{Key: "entityName", Value: fmt.Sprintf("%s:%s", entityType, name)},
 		{Key: "rabbitmqClusterName", Value: clusterName},
@@ -34,12 +34,12 @@ func CreateEntity(rabbitmqIntegration *integration.Integration, entityName, enti
 	clusterNameAttribute := integration.IDAttribute{Key: "clusterName", Value: clusterName}
 	endpoint := fmt.Sprintf("%s:%d", args.GlobalArgs.Hostname, args.GlobalArgs.Port)
 
-	entity, err = rabbitmqIntegration.EntityReportedVia(endpoint, fmt.Sprintf("%s:%s", endpoint, name), fmt.Sprintf("ra-%s", entityType), clusterNameAttribute)
+	entity, err := rabbitmqIntegration.EntityReportedVia(endpoint, fmt.Sprintf("%s:%s", endpoint, name), fmt.Sprintf("ra-%s", entityType), clusterNameAttribute)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return
+	return entity, metricNamespace, nil
 }
 
 func cleanEntityName(entityName, entityType string) string {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -35,8 +35,12 @@ func CollectEntityMetrics(rabbitmqIntegration *integration.Integration, bindings
 	bindingStats := collectBindingStats(bindings)
 	for _, dataItem := range dataItems {
 		entity, metricNamespace, err := dataItem.GetEntity(rabbitmqIntegration, clusterName)
-		if err != nil || entity == nil {
+		if err != nil {
 			log.Error("Could not create %s entity [%s]: %v", dataItem.EntityType(), dataItem.EntityName(), err)
+			continue
+		}
+		if entity == nil {
+			log.Debug("Not creating %s entity [%s] due to config", dataItem.EntityType(), dataItem.EntityName())
 			continue
 		}
 


### PR DESCRIPTION
The source of the issue is that the function returns `entity, metricNamespace, err` and the entity could be nil even if it is not an "error". The entity could be nil if, by config, the user is not interested into it