### PR TITLE
[NR-286408] chore: update docker compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ test:
 
 integration-test:
 	@echo "=== $(INTEGRATION) === [ test ]: running integration tests..."
-	@docker-compose -f tests/docker-compose.yml pull
-	@go test -v -tags=integration ./tests/. || (ret=$$?; docker-compose -f tests/docker-compose.yml down && exit $$ret)
-	@docker-compose -f tests/docker-compose.yml down
+	@docker compose -f tests/docker-compose.yml pull
+	@go test -v -tags=integration ./tests/. || (ret=$$?; docker compose -f tests/docker-compose.yml down && exit $$ret)
+	@docker compose -f tests/docker-compose.yml down
 
 install: compile
 	@echo "=== $(INTEGRATION) === [ install ]: installing bin/$(BINARY_NAME)..."

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -30,8 +30,9 @@ func dockerComposeRunMode(vars []string, ports []string, container string, detac
 		cmdLine = append(cmdLine, fmt.Sprintf("-p%s", ports[p]))
 	}
 	cmdLine = append(cmdLine, container)
-	fmt.Printf("executing: docker-compose %s\n", strings.Join(cmdLine, " "))
-	cmd := exec.Command("docker-compose", cmdLine...)
+	cmdLine = append([]string{"compose"}, cmdLine...)
+	fmt.Printf("executing: docker %s\n", strings.Join(cmdLine, " "))
+	cmd := exec.Command("docker", cmdLine...)
 	var outbuf, errbuf bytes.Buffer
 	cmd.Stdout = &outbuf
 	cmd.Stderr = &errbuf


### PR DESCRIPTION
`docker-compose` v1 is EOL, and we need to move to `docker compose` (wit a space).