### PR TITLE
changelog reverted to remove 2.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
-## v2.15.2 - 2025-08-13
-
-### ⛓️ Dependencies
-- Updated golang patch version to v1.24.6
-
 ## v2.15.1 - 2025-07-02
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
Reverting changelog to release nri-rabbitmq correctly.