### PR TITLE
chore(deps): update go to v1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-rabbitmq
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v3 v3.9.1

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
-github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "16672:15672"
 
   nri-rabbitmq:
-    image: golang:1.25.7-bookworm
+    image: golang:1.25.8-bookworm
     container_name: nri_rabbitmq
     working_dir: /code
     volumes:


### PR DESCRIPTION
### Changes:
- Update go version from v1.25.7 to v1.25.8.

Fixes Go stdlib CVEs reported by security scanning:
- CVE-2026-25679 (HIGH)
- CVE-2026-27139 (LOW)
- CVE-2026-27142 (MEDIUM)

Pinning to 1.25.8 (stable) instead of 1.26.1 (Renovabot #189 ).