### PR TITLE
fix: upgrade go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
+
+### security
+- update go to v1.25.9
 ## v2.16.0 - 2026-03-25
 
 ### 🛡️ Security notices

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-rabbitmq
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v3 v3.9.1

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "16672:15672"
 
   nri-rabbitmq:
-    image: golang:1.25.8-bookworm
+    image: golang:1.25.9-bookworm
     container_name: nri_rabbitmq
     working_dir: /code
     volumes:


### PR DESCRIPTION
## Summary
- Update Go to v1.25.9
- Run `go mod tidy` to update dependencies
- Update CHANGELOG.md with security entry

## Test plan
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)